### PR TITLE
Fix by macinjoke

### DIFF
--- a/src/components/TodoItem.js
+++ b/src/components/TodoItem.js
@@ -1,39 +1,30 @@
 import React from 'react'
 
 export default class TodoItem extends React.Component {
-  constructor(props) {
-    super(props)
-    this.state = {
-      todo: {
-        index: this.props.index,
-        content: this.props.content,
-        isCheck: this.props.isCheck,
-      }
-    }
-  }
-
   onCheckBoxChange() {
-    const todo = {
-      ...this.state.todo,
-      isCheck: !this.state.todo.isCheck,
-    }
-    this.setState({ todo })
-    this.props.onClick(todo)
+    const { index, content, isCheck } = this.props;
+    this.props.onClick({
+      index, content, isCheck: !isCheck
+    }) // 本当はindex だけ渡して isCheck を逆転させるロジックはreducer で書くべき
   }
 
   onRemoveButtonClicked() {
-    this.props.onRemove(this.state.todo)
+    const { index, content, isCheck } = this.props;
+    this.props.onRemove({
+      index: index, content: content, isCheck: isCheck
+    }) // 本当はindex だけ渡せば良い
   }
 
   render() {
+    const { index, content, isCheck } = this.props;
     return (
-      <li key={this.state.todo.index}>
+      <li key={index}>
         <input
           onChange={() => this.onCheckBoxChange()}
-          checked={this.state.todo.isCheck}
+          checked={isCheck}
           type="checkbox" />
-        {this.state.todo.content}
-        {this.state.todo.isCheck && <button onClick={() => this.onRemoveButtonClicked()}>REMOVE</button>}
+        {content}
+        {isCheck && <button onClick={() => this.onRemoveButtonClicked()}>REMOVE</button>}
       </li>
     )
   }

--- a/src/containers/Profile.js
+++ b/src/containers/Profile.js
@@ -6,11 +6,4 @@ const mapStateToProps = state => {
   return state.profile
 }
 
-const mapDispatchToProps = dispatch => {
-  return {
-    toggleProfile: (profile) => dispatch(actions.toggleProfile(profile)),
-    editProfile: (profile) => dispatch(actions.editProfile(profile))
-  }
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(Profile)
+export default connect(mapStateToProps, actions)(Profile)

--- a/src/containers/TodoList.js
+++ b/src/containers/TodoList.js
@@ -8,12 +8,4 @@ const mapStateToProps = state => {
   }
 }
 
-const mapDispatchToProps = dispatch => {
-  return {
-    addTodo: (todo) => dispatch(actions.addTodo(todo)),
-    checkTodo: (todo) => dispatch(actions.checkTodo(todo)),
-    removeTodo: (todo) => dispatch(actions.removeTodo(todo))
-  }
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(TodoList)
+export default connect(mapStateToProps, actions)(TodoList)


### PR DESCRIPTION
https://twitter.com/harhogefoo/status/1053850228778881024

# 改善点

- 659a2a2 mapDispatchToProps の記述の省略
  - この場合 `actions` をそのままconnect の第二引数に入れれば、元のコードと等価な挙動になります。
    - (connect 関数は引数のパターンが多すぎて難しいですね笑)
  - (ただの記述の省略なので好みの問題ではあります)
- 78ecb59 不必要なstate の削除
  - Redux でtodo リストの状態を管理しているのにReact のstate でさらにstate を管理する必要がないです。props を使ってあげてください。

# その他改善できそうなところ

その他に改善ができそうなのは reducer 周りですね。
現状、本来はreducer の責務であるはずのロジックがcomponent に書かれてしまっています。例えば checkTodo の引数はindex だけで良くて、reducer 側でindex をもとに特定のtodo のisCheck を変更するような処理にたほうが良いです。

addTodo の引数 は content,  (index の生成処理はreducer で行う)
checkTodo の引数 は index,
removeTodo の 引数は index,

にするほうが良いです。

そこらへんの話はredux の公式のtodo アプリexmapleが参考になると思います。
component 側も、reducer 側もスッキリしています。
https://github.com/reduxjs/redux/tree/master/examples/todos



 